### PR TITLE
feat: add missing openapi2typescript options

### DIFF
--- a/packages/max-plugin-openapi/src/index.ts
+++ b/packages/max-plugin-openapi/src/index.ts
@@ -21,9 +21,16 @@ export default (api: IApi) => {
           projectName: joi.string(),
           apiPrefix: joi.alternatives(joi.string(), joi.function()),
           namespace: joi.string(),
+          serversPath: joi.string(),
+          nullable: joi.boolean(),
+          dataFields: joi.array().items(joi.string()),
+          isCamelCase: joi.boolean(),
           hook: joi.object({
+            afterOpenApiDataInited: joi.function(),
             customFunctionName: joi.function(),
+            customTypeName: joi.function(),
             customClassName: joi.function(),
+            customFileNames: joi.function(),
           }),
         });
         return joi.alternatives(joi.array().items(itemSchema), itemSchema);


### PR DESCRIPTION
由于 openapi2typescript 引入的[破坏性更新](https://github.com/chenshuai2144/openapi2typescript/issues/127)，需要添加一些配置参数，但在 umi 中会导致 joi 验证失败。
这个 PR 补充了一些参数定义。